### PR TITLE
fix(deps): add tslib runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@dedalik/use-react",
       "version": "1.1.1",
       "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
       "devDependencies": {
         "@babel/cli": "^7.23.4",
         "@babel/core": "^7.23.7",
@@ -8718,8 +8721,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "dev": true,
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -89,5 +89,8 @@
     "dist",
     "LICENSE",
     "README.md"
-  ]
+  ],
+  "dependencies": {
+    "tslib": "^2.8.1"
+  }
 }


### PR DESCRIPTION
## What changed

- 

## Why

- 

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

## Notes

- Breaking changes: yes / no
- Docs updated: yes / no
